### PR TITLE
fix: humanize date to return "Today" for anything within 24 hours

### DIFF
--- a/message.test.ts
+++ b/message.test.ts
@@ -6,6 +6,7 @@ import {
   ProjectsSchema,
 } from "./message"
 import * as t from "io-ts"
+import { subDays } from "date-fns"
 
 function createTestHeroku({
   isRollback,
@@ -40,7 +41,8 @@ type ProjectSchemaType = t.TypeOf<typeof ProjectsSchema>
 
 describe("message", () => {
   test("humanize", () => {
-    const getCurrentDate = () => new Date("2019-10-28T00:00:00Z")
+    const CURRENT_DATE = new Date("2019-10-28T00:00:00Z")
+    const getCurrentDate = () => CURRENT_DATE
 
     const date = "2019-10-27T21:03:14Z"
 
@@ -50,7 +52,16 @@ describe("message", () => {
         timezone: "America/New_York",
         getCurrentDate,
       }),
-    ).toMatchInlineSnapshot(`"about 3 hours ago at 5:03 p.m. (Oct 27, 2019)"`)
+    ).toMatchInlineSnapshot(`"Today at 5:03 p.m. (Oct 27, 2019)"`)
+
+    const pastDate = subDays(CURRENT_DATE, 5).toISOString()
+    expect(
+      humanize({
+        date: pastDate,
+        timezone: "America/New_York",
+        getCurrentDate,
+      }),
+    ).toMatchInlineSnapshot(`"5 days ago at 8:00 p.m. (Oct 22, 2019)"`)
   })
 
   test("getMessage", async () => {
@@ -95,7 +106,7 @@ describe("message", () => {
         Object {
           "elements": Array [
             Object {
-              "text": "Last deployed: <https://github.com/ghost/time-to-deploy/commit/a8f68d19a290ad8a7eb19019de6ca58cecb444ce/|a8f68d1> about 5 hours ago at 4:11 p.m. (Nov 27, 2019)
+              "text": "Last deployed: <https://github.com/ghost/time-to-deploy/commit/a8f68d19a290ad8a7eb19019de6ca58cecb444ce/|a8f68d1> Today at 4:11 p.m. (Nov 27, 2019)
       ",
               "type": "mrkdwn",
             },
@@ -126,7 +137,7 @@ describe("message", () => {
         Object {
           "elements": Array [
             Object {
-              "text": "Last deployed: <https://github.com/ghost/time-to-deploy/commit/a8f68d19a290ad8a7eb19019de6ca58cecb444ce/|a8f68d1> about 5 hours ago at 4:11 p.m. (Nov 27, 2019)
+              "text": "Last deployed: <https://github.com/ghost/time-to-deploy/commit/a8f68d19a290ad8a7eb19019de6ca58cecb444ce/|a8f68d1> Today at 4:11 p.m. (Nov 27, 2019)
       *Attention*: Last deploy was a *rollback* by j.person@example.com",
               "type": "mrkdwn",
             },
@@ -162,7 +173,7 @@ describe("message", () => {
         Object {
           "elements": Array [
             Object {
-              "text": "Last deployed: <https://github.com/ghost/time-to-deploy/commit/a8f68d19a290ad8a7eb19019de6ca58cecb444ce/|a8f68d1> about 5 hours ago at 4:11 p.m. (Nov 27, 2019)
+              "text": "Last deployed: <https://github.com/ghost/time-to-deploy/commit/a8f68d19a290ad8a7eb19019de6ca58cecb444ce/|a8f68d1> Today at 4:11 p.m. (Nov 27, 2019)
       ",
               "type": "mrkdwn",
             },
@@ -219,7 +230,7 @@ describe("message", () => {
         Object {
           "elements": Array [
             Object {
-              "text": "Last deployed: <https://github.com/ghost/Acacia/commit/a8f68d19a290ad8a7eb19019de6ca58cecb444ce/|a8f68d1> about 5 hours ago at 4:11 p.m. (Nov 27, 2019)
+              "text": "Last deployed: <https://github.com/ghost/Acacia/commit/a8f68d19a290ad8a7eb19019de6ca58cecb444ce/|a8f68d1> Today at 4:11 p.m. (Nov 27, 2019)
       ",
               "type": "mrkdwn",
             },
@@ -238,7 +249,7 @@ describe("message", () => {
         Object {
           "elements": Array [
             Object {
-              "text": "Last deployed: <https://github.com/ghost/altair/commit/a8f68d19a290ad8a7eb19019de6ca58cecb444ce/|a8f68d1> about 5 hours ago at 4:11 p.m. (Nov 27, 2019)
+              "text": "Last deployed: <https://github.com/ghost/altair/commit/a8f68d19a290ad8a7eb19019de6ca58cecb444ce/|a8f68d1> Today at 4:11 p.m. (Nov 27, 2019)
       ",
               "type": "mrkdwn",
             },

--- a/message.ts
+++ b/message.ts
@@ -1,4 +1,4 @@
-import { formatDistance, format } from "date-fns"
+import { formatDistance, format, differenceInHours } from "date-fns"
 import { utcToZonedTime } from "date-fns-tz"
 import { GetLastDeployResponse } from "./heroku"
 import { KnownBlock } from "@slack/web-api"
@@ -8,6 +8,14 @@ import { Either, isLeft, isRight } from "fp-ts/lib/Either"
 import { flatten } from "fp-ts/lib/Array"
 import { AxiosError } from "axios"
 import { log } from "./logging"
+
+function getDateDistance(date: Date, getCurrentDate: () => Date): string {
+  const today = getCurrentDate()
+  if (Math.abs(differenceInHours(date, today)) < 24) {
+    return "Today"
+  }
+  return formatDistance(date, today, { addSuffix: true })
+}
 
 export function humanize({
   date,
@@ -20,15 +28,15 @@ export function humanize({
 }): string {
   const d = utcToZonedTime(date, timezone)
   return (
-    formatDistance(new Date(date), getCurrentDate(), { addSuffix: true }) +
+    getDateDistance(d, getCurrentDate) +
     " at " +
     format(d, "h:mm aaaa (MMM d, yyyy)")
   )
 }
 
 function getEnvsInfo(config: {
-  stagingEnvURL: string | null
-  productionEnvURL: string | null
+  readonly stagingEnvURL: string | null
+  readonly productionEnvURL: string | null
 }): string {
   if (config.stagingEnvURL != null && config.productionEnvURL != null) {
     return `• envs

--- a/s/build
+++ b/s/build
@@ -10,6 +10,7 @@ main() {
     ./node_modules/.bin/esbuild index.ts --platform=node --bundle --minify --sourcemap --target=node12 --outfile=build/index.js
     echo "zipping source files"
     zip --recurse-paths --junk-paths --quiet deploy.zip build/index.js
+    du -h deploy.zip
     echo "done"
 }
 


### PR DESCRIPTION
By using `Today` instead of `about $N minutes ago` we avoid having stale
distances in the message.

Also record zip size in build script output.