### PR TITLE
update: deploy createdAt time to use Heroku release's `updated_at`

### DIFF
--- a/heroku.ts
+++ b/heroku.ts
@@ -64,7 +64,7 @@ export function createHerokuClient(token: string) {
 
     const releaseJson = releasesRes.right
     const mostRecentSlugId = releaseJson[0].slug.id
-    const createdAt = releaseJson[0].created_at
+    const createdAt = releaseJson[0].updated_at
     const deployerEmail = releaseJson[0].user.email
     const isRollback = releaseJson[0].description
       .toLowerCase()


### PR DESCRIPTION
Releases are created by Heroku, then the release phase runs, which
typically completes in a matter of seconds and updates the `update_at`
field.

We want to use `updated_at` instead of `created_at` so the release time
is marked when the release phase finished, rather than when it started.