### PR TITLE
add(sentry): configure sentry releases & upload sourcemaps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
           key: time-to-deploy-cache-v1-{{ checksum "yarn.lock" }}
       - run:
           name: build
-          command: ./s/build
+          command: ./s/build fake-release-name
 
   shellcheck:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/python:3.9-node
+      - image: circleci/node:12.4.0
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -21,12 +21,12 @@ jobs:
             - ./node_modules
           key: time-to-deploy-cache-v1-{{ checksum "yarn.lock" }}
       - run:
-          name: run typechecker
+          name: run tests
           command: ./s/test
 
   lint:
     docker:
-      - image: circleci/python:3.9-node
+      - image: circleci/node:12.4.0
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:12.4.0
+      - image: circleci/python:3.9-node
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -26,7 +26,7 @@ jobs:
 
   lint:
     docker:
-      - image: circleci/node:12.4.0
+      - image: circleci/python:3.9-node
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -48,7 +48,7 @@ jobs:
 
   build:
     docker:
-      - image: circleci/node:12.4.0
+      - image: circleci/python:3.9-node
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This Slack bot provides info about Heroku deployments including:
    channel ID from the Slack URL. Don't forget to save your changes.
 
 8. Now we need to update our function with the actual code. Run `s/build` and
-   `s/deploy`. If you didn't name your lambda function `time-to-deploy`, be
+   `SENTRY_ORG= s/deploy`. If you didn't name your lambda function `time-to-deploy`, be
    sure to update the `s/deploy` script before running it.
 
 ### Test the Function

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ This Slack bot provides info about Heroku deployments including:
    `SENTRY_ORG= s/deploy`. If you didn't name your lambda function `time-to-deploy`, be
    sure to update the `s/deploy` script before running it.
 
+   ```sh
+   release=$(git rev-parse head)
+   s/build "${release}"
+   SENTRY_ORG= s/deploy "${release}"
+   ```
+
 ### Test the Function
 
 Run the function and ensure the deploy message appears in your Slack channel.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {},
   "devDependencies": {
+    "@sentry/cli": "^1.63.1",
     "@types/bunyan": "^1.8.6",
     "@types/express": "^4.17.2",
     "@types/jest": "^24.0.23",

--- a/s/build
+++ b/s/build
@@ -7,7 +7,19 @@ main() {
     rm -rf build
     rm -f deploy.zip
     echo "compiling source files"
-    ./node_modules/.bin/esbuild src/index.ts --platform=node --bundle --minify --sourcemap --target=node12 --outfile=build/index.js
+
+    release_name="$(git rev-parse head)"
+
+    ./node_modules/.bin/esbuild \
+        src/index.ts \
+        --platform=node \
+        --define:process.env.TTD_SENTRY_RELEASE="'${release_name}'" \
+        --bundle \
+        --minify \
+        --sourcemap \
+        --target=node12 \
+        --outfile=build/index.js
+
     echo "zipping source files"
     zip --recurse-paths --junk-paths --quiet deploy.zip build/index.js
     du -h deploy.zip

--- a/s/build
+++ b/s/build
@@ -1,29 +1,65 @@
-#!/bin/sh
-set -o errexit
-set -o nounset
+#!/usr/bin/env python3
+import subprocess
+import argparse
+import logging
+import os
+import shutil
 
-main() {
-    echo "removing old deploy zip & clearing build dir"
-    rm -rf build
-    rm -f deploy.zip
-    echo "compiling source files"
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__file__)
 
-    release_name="$(git rev-parse head)"
 
-    ./node_modules/.bin/esbuild \
-        src/index.ts \
-        --platform=node \
-        --define:process.env.TTD_SENTRY_RELEASE="'${release_name}'" \
-        --bundle \
-        --minify \
-        --sourcemap \
-        --target=node12 \
-        --outfile=build/index.js
+def main() -> None:
+    parser = argparse.ArgumentParser(description="build time-to-deploy")
+    parser.add_argument(
+        "release",
+        type=str,
+        help="release name used for in Sentry, usually a git sha",
+    )
+    args = parser.parse_args()
+    release_name = args.release
 
-    echo "zipping source files"
-    zip --recurse-paths --junk-paths --quiet deploy.zip build/index.js
-    du -h deploy.zip
-    echo "done"
-}
+    logging.info("removing old deploy zip & clearing build dir")
 
-main "$@"
+    shutil.rmtree("build")
+    os.remove("deploy.zip")
+
+    logging.info("compiling source files for release: %s", release_name)
+
+    subprocess.run(
+        [
+            "./node_modules/.bin/esbuild",
+            "src/index.ts",
+            "--platform=node",
+            f"--define:process.env.TTD_SENTRY_RELEASE='{release_name}'",
+            "--bundle",
+            "--minify",
+            "--sourcemap",
+            "--target=node12",
+            "--outfile=build/index.js",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    logging.info("zipping source files")
+    subprocess.run(
+        [
+            "zip",
+            "--recurse-paths",
+            "--junk-paths",
+            "--quiet",
+            "deploy.zip",
+            "build/index.js",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    res = subprocess.run(["du", "-h", "deploy.zip"], check=True, capture_output=True)
+    logging.info("total size: %s", res.stdout.decode().strip())
+    logging.info("done")
+
+
+if __name__ == "__main__":
+    main()

--- a/s/build
+++ b/s/build
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import subprocess
 import argparse
 import logging
@@ -17,7 +19,7 @@ def main() -> None:
         help="release name used for in Sentry, usually a git sha",
     )
     args = parser.parse_args()
-    release_name = args.release
+    release_name: str = args.release
 
     logging.info("removing old deploy zip & clearing build dir")
 

--- a/s/build
+++ b/s/build
@@ -6,6 +6,7 @@ import argparse
 import logging
 import os
 import shutil
+from contextlib import suppress
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__file__)
@@ -23,8 +24,9 @@ def main() -> None:
 
     logging.info("removing old deploy zip & clearing build dir")
 
-    shutil.rmtree("build")
-    os.remove("deploy.zip")
+    shutil.rmtree("build", ignore_errors=True)
+    with suppress(FileNotFoundError):
+        os.remove("deploy.zip")
 
     logging.info("compiling source files for release: %s", release_name)
 

--- a/s/deploy
+++ b/s/deploy
@@ -25,7 +25,7 @@ def main() -> None:
         help="release name used for in Sentry, usually a git sha",
     )
     args = parser.parse_args()
-    release_name = args.release
+    release_name: str = args.release
 
     if not os.getenv("SENTRY_ORG"):
         logger.info("missing required env var: SENTRY_ORG")

--- a/s/deploy
+++ b/s/deploy
@@ -2,8 +2,36 @@
 set -o errexit
 set -o nounset
 
+
+readonly SENTRY_PROJECT_SLUG="time-to-deploy"
+
 main() {
-    aws lambda update-function-code --function-name time-to-deploy --zip-file "fileb://$PWD/deploy.zip"
+    release_name="$(git rev-parse head)"
+
+    echo "starting sentry release"
+
+    ./node_modules/.bin/sentry-cli releases \
+        --project "${SENTRY_PROJECT_SLUG}" \
+        new "${release_name}"
+
+    ./node_modules/.bin/sentry-cli releases \
+        --project "${SENTRY_PROJECT_SLUG}" \
+        files "${release_name}" \
+        upload-sourcemaps ./build
+
+    echo "uploading code"
+
+    aws lambda update-function-code \
+        --function-name time-to-deploy \
+        --zip-file "fileb://${PWD}/deploy.zip" \
+        --no-cli-pager
+
+    echo "finalizing sentry release"
+
+    ./node_modules/.bin/sentry-cli releases \
+        finalize "${release_name}"
+
+    echo "done"
 }
 
 main "$@"

--- a/s/deploy
+++ b/s/deploy
@@ -1,37 +1,93 @@
-#!/bin/sh
-set -o errexit
-set -o nounset
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import argparse
+import logging
+import os
+import subprocess
+
+SENTRY_PROJECT_SLUG = "time-to-deploy"
 
 
-readonly SENTRY_PROJECT_SLUG="time-to-deploy"
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__file__)
 
-main() {
-    release_name="$(git rev-parse head)"
 
-    echo "starting sentry release"
+PWD = os.getcwd()
 
-    ./node_modules/.bin/sentry-cli releases \
-        --project "${SENTRY_PROJECT_SLUG}" \
-        new "${release_name}"
 
-    ./node_modules/.bin/sentry-cli releases \
-        --project "${SENTRY_PROJECT_SLUG}" \
-        files "${release_name}" \
-        upload-sourcemaps ./build
+def main() -> None:
+    parser = argparse.ArgumentParser(description="build time-to-deploy")
+    parser.add_argument(
+        "release",
+        type=str,
+        help="release name used for in Sentry, usually a git sha",
+    )
+    args = parser.parse_args()
+    release_name = args.release
 
-    echo "uploading code"
+    if not os.getenv("SENTRY_ORG"):
+        logger.info("missing required env var: SENTRY_ORG")
+        sys.exit(1)
 
-    aws lambda update-function-code \
-        --function-name time-to-deploy \
-        --zip-file "fileb://${PWD}/deploy.zip" \
-        --no-cli-pager
+    logging.info("starting sentry release for: %s", release_name)
 
-    echo "finalizing sentry release"
+    subprocess.run(
+        [
+            "./node_modules/.bin/sentry-cli",
+            "releases",
+            "--project",
+            SENTRY_PROJECT_SLUG,
+            "new",
+            release_name,
+        ],
+        check=True,
+        capture_output=True,
+    )
 
-    ./node_modules/.bin/sentry-cli releases \
-        finalize "${release_name}"
+    subprocess.run(
+        [
+            "./node_modules/.bin/sentry-cli",
+            "releases",
+            "--project",
+            SENTRY_PROJECT_SLUG,
+            "files",
+            release_name,
+            "upload-sourcemaps",
+            "./build",
+        ],
+        check=True,
+        capture_output=True,
+    )
 
-    echo "done"
-}
+    logging.info("uploading code")
 
-main "$@"
+    subprocess.run(
+        [
+            "aws",
+            "lambda",
+            "update-function-code",
+            "--function-name",
+            "time-to-deploy",
+            "--zip-file",
+            f"fileb://{PWD}/deploy.zip",
+            "--no-cli-pager",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    logging.info("finalizing sentry release")
+
+    subprocess.run(
+        ["./node_modules/.bin/sentry-cli", "releases", "finalize", release_name],
+        check=True,
+        capture_output=True,
+    )
+
+    logging.info("done")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,9 @@ import { isLeft } from "fp-ts/lib/Either"
 import { PathReporter } from "io-ts/lib/PathReporter"
 import * as Sentry from "@sentry/node"
 
-Sentry.init()
+Sentry.init({
+  release: process.env.TTD_SENTRY_RELEASE,
+})
 
 dotenv.config()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -574,6 +574,17 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@sentry/cli@^1.63.1":
+  version "1.63.1"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.63.1.tgz#306a0591190432574082d4ce4a72363201972461"
+  integrity sha512-qksIcrnObkGvtubs1FmW4EMXLo7R43Dobgzuxnyoebo1Y5KfRLziiw6H+ux8D4c1Nui4SuvDGDq0ObAfO5oE6Q==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    mkdirp "^0.5.5"
+    node-fetch "^2.6.0"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+
 "@sentry/core@6.2.2":
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.2.2.tgz#ec86b5769f8855f43cb58e839f81f87074ec9a3f"
@@ -3323,6 +3334,13 @@ mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
+mkdirp@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
+  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+  dependencies:
+    minimist "^1.2.5"
+
 moment@^2.10.6:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
@@ -3384,6 +3402,11 @@ newtype-ts@^0.3.4:
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+
+node-fetch@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3707,7 +3730,7 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-progress@^2.0.0:
+progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
 
@@ -3717,6 +3740,11 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.28:
   version "1.4.0"


### PR DESCRIPTION
We compile and minify the code via esbuild which without sourcemaps gives
garbage stack traces in Sentry.

So this change sets up releases and uploads the sourcemaps for a given
release.

Also substitute in the release env var at build time, which is easier
than updating an env var in lambda.