### PR TITLE
ref(handler): `assertNever` so tsc check all event types are handled

### DIFF
--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,3 +1,3 @@
 export function assertNever(arg: never): never {
-    throw Error(`expected never, got: ${arg}`)
+  throw Error(`expected never, got: ${arg}`)
 }

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,0 +1,3 @@
+export function assertNever(arg: never): never {
+    throw Error(`expected never, got: ${arg}`)
+}

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -6,6 +6,7 @@ import { Slack } from "./slack"
 import { DB } from "./db"
 import { log } from "./logging"
 import { addWeeks, getUnixTime } from "date-fns"
+import { assertNever } from "./assert"
 
 export async function main({
   slack,
@@ -91,6 +92,8 @@ export async function main({
       })
 
       log.info("updated slack message", result)
+    } else {
+      assertNever(eventInfo)
     }
   } catch (e) {
     log.warn("Problem sending message to slack", e)


### PR DESCRIPTION
When adding another variant to the union tsc can check ensure we handle
it, otherwise we'll get a compiler error.