### PR TITLE
add better logging api

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -59,7 +59,7 @@ async function createAccessTokenForInstall({
     },
   })
   if (isLeft(res)) {
-    log.warn("problem generating access token", installId)
+    log.warn("problem generating access token", { installId })
     return res
   }
   return res
@@ -125,7 +125,7 @@ export function createGitHubClient({
       token: jwt,
     })
     if (isLeft(tokenRes)) {
-      log.warn("failed to create access token", tokenRes)
+      log.warn("failed to create access token", { tokenRes })
       return null
     }
     const token: string = tokenRes.right.token
@@ -138,7 +138,7 @@ export function createGitHubClient({
       },
     })
     if (isLeft(res)) {
-      log.warn("failed to compare commit shas", res)
+      log.warn("failed to compare commit shas", { res })
       return null
     }
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -66,13 +66,13 @@ export async function main({
         if (isRight(res)) {
           log.info("saved message id")
         } else {
-          log.info("problem saving message", res.left)
+          log.info("problem saving message", { left: res.left })
         }
       } else {
         log.info("problem parsing slack response info")
       }
 
-      log.info("Sent message to slack", result)
+      log.info("Sent message to slack", { result })
     } else if (eventInfo.kind === "api_call") {
       log.info("handling api_call event")
       if (eventInfo.authToken !== HTTP_AUTH_TOKEN) {
@@ -95,8 +95,8 @@ export async function main({
     } else {
       assertNever(eventInfo)
     }
-  } catch (e) {
-    log.warn("Problem sending message to slack", e)
+  } catch (e: unknown) {
+    log.warn("Problem sending message to slack", { e })
   }
 }
 

--- a/src/heroku.ts
+++ b/src/heroku.ts
@@ -58,7 +58,7 @@ export function createHerokuClient(token: string) {
       },
     })
     if (isLeft(releasesRes)) {
-      log.warn("problem parsing release info", envName)
+      log.warn("problem parsing release info", { envName })
       return releasesRes
     }
 
@@ -82,7 +82,7 @@ export function createHerokuClient(token: string) {
       },
     })
     if (isLeft(slugRes)) {
-      log.warn("problem parsing slug res", envName)
+      log.warn("problem parsing slug res", { envName })
       return slugRes
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export async function handler(event: unknown) {
   const env = EnvShape.decode(process.env)
 
   if (isLeft(env)) {
-    log.error({ violations: PathReporter.report(env) }, "problem parsing env")
+    log.error("problem parsing env", { violations: PathReporter.report(env) })
     return
   }
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -34,46 +34,37 @@ class CustomLogger {
   constructor(logger: bunyan) {
     this.logger = logger
   }
-  info(context: LogContext): void
-  info(message: string, context?: LogContext): void
-  info(contextOrMessage: LogContext | string, context?: LogContext): void {
+  private log(
+    type: "info" | "warn" | "error",
+    contextOrMessage: LogContext | string,
+    context?: LogContext,
+  ): void {
     if (typeof contextOrMessage === "object") {
-      baselogger.info(contextOrMessage)
+      baselogger[type](contextOrMessage)
       return
     }
     if (typeof context != null) {
-      baselogger.info(context, contextOrMessage)
+      baselogger[type](context, contextOrMessage)
       return
     }
-    baselogger.info(contextOrMessage)
+    baselogger[type](contextOrMessage)
+  }
+  info(context: LogContext): void
+  info(message: string, context?: LogContext): void
+  info(contextOrMessage: LogContext | string, context?: LogContext): void {
+    this.log("info", contextOrMessage, context)
   }
 
   warn(context: LogContext): void
   warn(message: string, context?: LogContext): void
   warn(contextOrMessage: LogContext | string, context?: LogContext): void {
-    if (typeof contextOrMessage === "object") {
-      baselogger.warn(contextOrMessage)
-      return
-    }
-    if (typeof context != null) {
-      baselogger.warn(context, contextOrMessage)
-      return
-    }
-    baselogger.warn(contextOrMessage)
+    this.log("warn", contextOrMessage, context)
   }
 
   error(context: LogContext): void
   error(message: string, context?: LogContext): void
   error(contextOrMessage: LogContext | string, context?: LogContext): void {
-    if (typeof contextOrMessage === "object") {
-      baselogger.error(contextOrMessage)
-      return
-    }
-    if (typeof context != null) {
-      baselogger.error(context, contextOrMessage)
-      return
-    }
-    baselogger.error(contextOrMessage)
+    this.log("error", contextOrMessage, context)
   }
   child(context: LogContext): CustomLogger {
     return new CustomLogger(this.logger.child(context))

--- a/src/message.ts
+++ b/src/message.ts
@@ -298,13 +298,7 @@ function getProjectSettings(env: { readonly TTD_PROJECT_SETTINGS: string }) {
   if (isRight(parsedResult)) {
     return parsedResult.right
   }
-  log.error(
-    `Problem parsing project settings: ${JSON.stringify(
-      { res: parsedResult.left },
-      null,
-      2,
-    )}`,
-  )
+  log.error("Problem parsing project settings", { res: parsedResult.left })
   throw Error("problem parsing project settings")
 }
 
@@ -327,7 +321,7 @@ async function getLastDeploy({
     envName,
   })
   if (isLeft(res)) {
-    log.warn("failed to get recent deploy info", envName)
+    log.warn("failed to get recent deploy info", { envName })
     return null
   }
   return res.right
@@ -344,7 +338,7 @@ async function getStagingSha({
     envName,
   })
   if (isLeft(res)) {
-    log.warn("failed to get staging sha", envName)
+    log.warn("failed to get staging sha", { envName })
     return null
   }
   return res.right.sha


### PR DESCRIPTION
This change swaps the order of message and context. So the message goes before the context. This change also restricts the types, so you can only pass a message with context. Previously you could pass multiple strings, which would be concatenated.

```ts
// before
log.info("user logged in")
// after
log.info("user logged in")
```


```ts
// before
log.info({user_name: user.name}, "user logged in")
// after
log.info("user logged in", {user_name: user.name})
```

```ts
// before
log.info("user logged in", user.name)
// after
log.info("user logged in", user.name) // type error
```