### PR TITLE
fix(deploy): disable the pager in the deploy script

### DIFF
--- a/s/deploy
+++ b/s/deploy
@@ -3,7 +3,10 @@ set -o errexit
 set -o nounset
 
 main() {
-    aws lambda update-function-code --function-name time-to-deploy --zip-file "fileb://$PWD/deploy.zip"
+    aws lambda update-function-code \
+      --function-name time-to-deploy \
+      --zip-file "fileb://$PWD/deploy.zip" \
+      --no-cli-pager
 }
 
 main "$@"


### PR DESCRIPTION
the AWS cli defaults to using a pager when there is a lot of content,
which is super annoying for a script.